### PR TITLE
Task統計APIの新規実装 (Issue #6)

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -45,6 +45,13 @@ class TasksController < ApplicationController
     render :stats
   end
 
+  def report
+    service = Tasks::ReportService.new
+    service.call
+    @report = service.result
+    render :report
+  end
+
   private
 
   def create_params

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,5 @@ class Task < ApplicationRecord
   belongs_to :genre
 
   enum priority: { low: 0, medium: 1, high: 2 }
+  enum status: { not_started: 0, in_progress: 1, completed: 5 }
 end

--- a/app/services/tasks/report_service.rb
+++ b/app/services/tasks/report_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Tasks
+  class ReportService
+    attr_reader :result
+
+    def initialize
+      @result = nil
+    end
+
+    def call
+      @result = calculate_report
+    end
+
+    private
+
+    def calculate_report
+      {
+        total_count: total_count,
+        count_by_status: count_by_status,
+        completion_rate: completion_rate
+      }
+    end
+
+    def total_count
+      Task.count
+    end
+
+    def count_by_status
+      {
+        not_started: Task.not_started.count,
+        in_progress: Task.in_progress.count,
+        completed: Task.completed.count
+      }
+    end
+
+    def completion_rate
+      return 0.0 if total_count.zero?
+
+      completed_count = Task.completed.count
+      (completed_count.to_f / total_count * 100).round(1)
+    end
+  end
+end

--- a/app/views/tasks/report.json.jbuilder
+++ b/app/views/tasks/report.json.jbuilder
@@ -1,0 +1,7 @@
+json.totalCount @report[:total_count]
+json.countByStatus do
+  json.notStarted @report[:count_by_status][:not_started]
+  json.inProgress @report[:count_by_status][:in_progress]
+  json.completed @report[:count_by_status][:completed]
+end
+json.completionRate @report[:completion_rate]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :tasks , defaults: {format: 'json'} do
     collection do
       get :stats, to: "tasks#stats", defaults: {format: 'json'}
+      get :report, to: "tasks#report", defaults: {format: 'json'}
     end
     member do
       post :status, to: "tasks#update_status", defaults: {format: 'json'}

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -342,4 +342,99 @@ RSpec.describe 'Tasks API', type: :request do
       end
     end
   end
+
+  describe 'GET /tasks/report' do
+    context 'タスクが存在する場合' do
+      before do
+        # not_started: 2件
+        Task.create!(name: 'タスク1', genre: genre, status: :not_started, priority: :low)
+        Task.create!(name: 'タスク2', genre: genre, status: :not_started, priority: :medium)
+
+        # in_progress: 1件
+        Task.create!(name: 'タスク3', genre: genre, status: :in_progress, priority: :high)
+
+        # completed: 2件
+        Task.create!(name: 'タスク4', genre: genre, status: :completed, priority: :medium)
+        Task.create!(name: 'タスク5', genre: genre, status: :completed, priority: :high)
+      end
+
+      it 'ステータスコード200が返されること' do
+        get '/tasks/report'
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'レスポンスにtotalCountが含まれること' do
+        get '/tasks/report'
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to have_key('totalCount')
+        expect(json_response['totalCount']).to eq(5)
+      end
+
+      it 'レスポンスにcountByStatusが含まれること' do
+        get '/tasks/report'
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to have_key('countByStatus')
+        expect(json_response['countByStatus']).to be_a(Hash)
+        expect(json_response['countByStatus']['notStarted']).to eq(2)
+        expect(json_response['countByStatus']['inProgress']).to eq(1)
+        expect(json_response['countByStatus']['completed']).to eq(2)
+      end
+
+      it 'レスポンスにcompletionRateが含まれること' do
+        get '/tasks/report'
+
+        json_response = JSON.parse(response.body)
+        expect(json_response).to have_key('completionRate')
+        expect(json_response['completionRate']).to eq(40.0)
+      end
+    end
+
+    context 'タスクが0件の場合' do
+      it 'ステータスコード200が返されること' do
+        get '/tasks/report'
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'totalCountが0であること' do
+        get '/tasks/report'
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['totalCount']).to eq(0)
+      end
+
+      it 'countByStatusの各ステータスが0であること' do
+        get '/tasks/report'
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['countByStatus']['notStarted']).to eq(0)
+        expect(json_response['countByStatus']['inProgress']).to eq(0)
+        expect(json_response['countByStatus']['completed']).to eq(0)
+      end
+
+      it 'completionRateが0.0であること' do
+        get '/tasks/report'
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['completionRate']).to eq(0.0)
+      end
+    end
+
+    context '完了率が小数点以下1桁で表示される場合' do
+      before do
+        # 3件中1件完了 -> 33.3%
+        Task.create!(name: 'タスク1', genre: genre, status: :not_started, priority: :low)
+        Task.create!(name: 'タスク2', genre: genre, status: :not_started, priority: :medium)
+        Task.create!(name: 'タスク3', genre: genre, status: :completed, priority: :high)
+      end
+
+      it '完了率が小数点以下1桁で計算されること' do
+        get '/tasks/report'
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['completionRate']).to eq(33.3)
+      end
+    end
+  end
 end

--- a/spec/services/tasks/report_service_spec.rb
+++ b/spec/services/tasks/report_service_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::ReportService do
+  let(:genre) { Genre.create!(name: 'テストジャンル') }
+
+  describe '#call' do
+    context 'タスクが存在する場合' do
+      before do
+        # not_started: 2件
+        Task.create!(name: 'タスク1', genre: genre, status: :not_started, priority: :low)
+        Task.create!(name: 'タスク2', genre: genre, status: :not_started, priority: :medium)
+
+        # in_progress: 1件
+        Task.create!(name: 'タスク3', genre: genre, status: :in_progress, priority: :high)
+
+        # completed: 2件
+        Task.create!(name: 'タスク4', genre: genre, status: :completed, priority: :medium)
+        Task.create!(name: 'タスク5', genre: genre, status: :completed, priority: :high)
+      end
+
+      it '全タスク数を正しく計算できること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:total_count]).to eq(5)
+      end
+
+      it 'ステータス別タスク数を正しく集計できること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:count_by_status][:not_started]).to eq(2)
+        expect(service.result[:count_by_status][:in_progress]).to eq(1)
+        expect(service.result[:count_by_status][:completed]).to eq(2)
+      end
+
+      it '完了率を小数点以下1桁で正しく計算できること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        # 5件中2件が完了 -> 40.0%
+        expect(service.result[:completion_rate]).to eq(40.0)
+      end
+    end
+
+    context 'タスクが0件の場合' do
+      it '全タスク数が0であること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:total_count]).to eq(0)
+      end
+
+      it 'ステータス別タスク数がすべて0であること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:count_by_status][:not_started]).to eq(0)
+        expect(service.result[:count_by_status][:in_progress]).to eq(0)
+        expect(service.result[:count_by_status][:completed]).to eq(0)
+      end
+
+      it '完了率が0.0であること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:completion_rate]).to eq(0.0)
+      end
+    end
+
+    context '全てのタスクが完了している場合' do
+      before do
+        Task.create!(name: 'タスク1', genre: genre, status: :completed, priority: :low)
+        Task.create!(name: 'タスク2', genre: genre, status: :completed, priority: :medium)
+        Task.create!(name: 'タスク3', genre: genre, status: :completed, priority: :high)
+      end
+
+      it '完了率が100.0であること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:completion_rate]).to eq(100.0)
+      end
+    end
+
+    context '完了タスクが0件の場合' do
+      before do
+        Task.create!(name: 'タスク1', genre: genre, status: :not_started, priority: :low)
+        Task.create!(name: 'タスク2', genre: genre, status: :in_progress, priority: :medium)
+      end
+
+      it '完了率が0.0であること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:completion_rate]).to eq(0.0)
+      end
+    end
+
+    context '完了率が小数点以下1桁で切り捨てされる場合' do
+      before do
+        # 3件中1件完了 -> 33.333...% -> 33.3%
+        Task.create!(name: 'タスク1', genre: genre, status: :not_started, priority: :low)
+        Task.create!(name: 'タスク2', genre: genre, status: :not_started, priority: :medium)
+        Task.create!(name: 'タスク3', genre: genre, status: :completed, priority: :high)
+      end
+
+      it '完了率が小数点以下1桁で計算されること' do
+        service = Tasks::ReportService.new
+        service.call
+
+        expect(service.result[:completion_rate]).to eq(33.3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
   ## 概要
   Issue #6 の対応として、タスク統計情報を返すAPIエンドポイント `/tasks/report` を実装しました。

   ## 実装内容

   ### 1. Taskモデルにstatus enumを追加
   - `not_started` (0): 未着手
   - `in_progress` (1): 進行中
   - `completed` (5): 完了

   ### 2. Tasks::ReportServiceの実装
   - 全タスク数の集計
   - ステータス別タスク数の集計
   - タスク完了率の計算（小数点以下1桁）

   ### 3. APIエンドポイントの追加
   - **エンドポイント**: `GET /tasks/report`
   - **レスポンス形式**: JSON (camelCase)
   - **レスポンスデータ**:
     - `totalCount`: 全タスクの総数
     - `countByStatus`: ステータスごとのタスク数 (notStarted, inProgress, completed)
     - `completionRate`: 完了率（小数点以下1桁のパーセンテージ）

   ## テスト
   - Tasks::ReportServiceの単体テスト
     - タスクが存在する場合の集計
     - タスクが0件の場合のエッジケース
     - 完了率の各種パターン（0%, 100%, 小数点計算）
   - APIエンドポイントの結合テスト
     - 正常系のレスポンス検証
     - エッジケースの検証

   ## コミット構成
   1. Taskモデルにstatus enumを追加
   2. Tasks::ReportServiceを実装
   3. タスクレポートAPIエンドポイントを追加

   Closes #6